### PR TITLE
Correct RBAC rules and binding

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,26 @@ metadata:
   namespace: system
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - secret
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - couchbase.btburnett.com
   resources:
   - couchbaseindexsets
@@ -33,3 +53,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - couchbase.com
+  resources:
+  - couchbaseclusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: manager-role
 subjects:
 - kind: ServiceAccount

--- a/controllers/couchbaseindexset_controller.go
+++ b/controllers/couchbaseindexset_controller.go
@@ -64,6 +64,9 @@ type CouchbaseIndexSetReconcileContext struct {
 //+kubebuilder:rbac:groups=couchbase.btburnett.com,namespace=system,resources=couchbaseindexsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=couchbase.btburnett.com,namespace=system,resources=couchbaseindexsets/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=couchbase.btburnett.com,namespace=system,resources=couchbaseindexsets/finalizers,verbs=update
+//+kubebuilder:rbac:groups=batch,namespace=system,resources=jobs,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=couchbase.com,namespace=system,resources=couchbaseclusters,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",namespace=system,resources=secret,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/docs/install/v1.0.0.yaml
+++ b/docs/install/v1.0.0.yaml
@@ -298,6 +298,26 @@ metadata:
   namespace: default
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - secret
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - couchbase.btburnett.com
   resources:
   - couchbaseindexsets
@@ -323,6 +343,14 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - couchbase.com
+  resources:
+  - couchbaseclusters
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -381,8 +409,8 @@ metadata:
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: manager-role
+  kind: Role
+  name: cb-index-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: cb-index-operator-controller-manager


### PR DESCRIPTION
Motivation
------------
There are some missing rights on the RBAC roles and the binding is
incorrect. This will cause failures on clusters with RBAC enabled.

Modifications
---------------
Add the required RBAC rules to the controller and update the manifests.

Correct the binding to be a Role binding instead of ClusterRole.