### PR TITLE
Don't try to push Docker images for forked PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Build and push
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: make docker-build docker-push IMG=ghcr.io/brantburnett/couchbase-index-operator:${{ env.VERSION }}
+      - name: Build
+        if: ${{ github.event.pull_request.head.repo.fork }}
+        run: make docker-build IMG=ghcr.io/brantburnett/couchbase-index-operator:${{ env.VERSION }}


### PR DESCRIPTION
This avoids security failures on the build