### PR TITLE
Allow hyphens in index names

### DIFF
--- a/api/v1beta1/couchbaseindexset_types.go
+++ b/api/v1beta1/couchbaseindexset_types.go
@@ -42,7 +42,7 @@ type GlobalSecondaryIndex struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	//+kubebuilder:validation:MinLength:=1
-	//+kubebuilder:validation:Pattern:=^[A-Za-z][A-Za-z0-9#_]*$
+	//+kubebuilder:validation:Pattern:=^[A-Za-z][A-Za-z0-9#_\-]*$
 	// Name of the index
 	Name string `json:"name"`
 	//+kubebuilder:validation:MinLength:=1

--- a/config/crd/bases/couchbase.btburnett.com_couchbaseindexsets.yaml
+++ b/config/crd/bases/couchbase.btburnett.com_couchbaseindexsets.yaml
@@ -129,7 +129,7 @@ spec:
                     name:
                       description: Name of the index
                       minLength: 1
-                      pattern: ^[A-Za-z][A-Za-z0-9#_]*$
+                      pattern: ^[A-Za-z][A-Za-z0-9#_\-]*$
                       type: string
                     numReplicas:
                       description: Number of replicas

--- a/docs/install/v1.0.0.yaml
+++ b/docs/install/v1.0.0.yaml
@@ -114,7 +114,7 @@ spec:
                     name:
                       description: Name of the index
                       minLength: 1
-                      pattern: ^[A-Za-z][A-Za-z0-9#_]*$
+                      pattern: ^[A-Za-z][A-Za-z0-9#_\-]*$
                       type: string
                     numReplicas:
                       description: Number of replicas


### PR DESCRIPTION
The regex was based on some incorrect documentation, hyphens are allowed.